### PR TITLE
Refactor - UploadFileProcessingController - Use IHttpClientFactory instead of HttpClient

### DIFF
--- a/src/EPR.Calculator.Frontend.UnitTests/UploadFileProcessingControllerTest.cs
+++ b/src/EPR.Calculator.Frontend.UnitTests/UploadFileProcessingControllerTest.cs
@@ -1,8 +1,10 @@
 ﻿using System.Net;
+using System.Net.Http;
 using EPR.Calculator.Frontend.Controllers;
 using EPR.Calculator.Frontend.UnitTests.Mocks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Http;
 using Moq;
 using Moq.Protected;
 
@@ -14,6 +16,7 @@ namespace EPR.Calculator.Frontend.UnitTests
         [TestMethod]
         public void UploadFileProcessingController_Success_Result_Test()
         {
+            // Mock HttpMessageHandler
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler
                 .Protected()
@@ -26,9 +29,22 @@ namespace EPR.Calculator.Frontend.UnitTests
                         Content = new StringContent("response content"),
                     });
 
+            // Create HttpClient with the mocked handler
             var httpClient = new HttpClient(mockHttpMessageHandler.Object);
-            var controller = new UploadFileProcessingController(GetConfigurationValues(), httpClient);
+
+            // Mock IHttpClientFactory
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            mockHttpClientFactory
+                .Setup(_ => _.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient);
+
+            // Create controller with the mocked factory
+            var controller = new UploadFileProcessingController(GetConfigurationValues(), mockHttpClientFactory.Object);
+
+            // Act
             var result = controller.Index(MockData.GetSchemeParameterTemplateValues().ToList()) as OkObjectResult;
+
+            // Assert
             Assert.IsNotNull(result);
             Assert.AreEqual(result.StatusCode, 200);
         }
@@ -43,13 +59,17 @@ namespace EPR.Calculator.Frontend.UnitTests
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
-                {
-                    StatusCode = HttpStatusCode.BadRequest,
-                    Content = new StringContent("response content"),
-                });
+                    {
+                        StatusCode = HttpStatusCode.BadRequest,
+                        Content = new StringContent("response content"),
+                    });
 
             var httpClient = new HttpClient(mockHttpMessageHandler.Object);
-            var controller = new UploadFileProcessingController(GetConfigurationValues(), httpClient);
+            var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            mockHttpClientFactory
+                .Setup(_ => _.CreateClient(It.IsAny<string>()))
+                    .Returns(httpClient);
+            var controller = new UploadFileProcessingController(GetConfigurationValues(), mockHttpClientFactory.Object);
             var result = controller.Index(MockData.GetSchemeParameterTemplateValues().ToList()) as BadRequestObjectResult;
             Assert.IsNotNull(result);
             Assert.AreNotEqual(result.StatusCode, 201);

--- a/src/EPR.Calculator.Frontend/Controllers/UploadFileProcessingController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/UploadFileProcessingController.cs
@@ -8,20 +8,22 @@ namespace EPR.Calculator.Frontend.Controllers
     public class UploadFileProcessingController : Controller
     {
         private readonly IConfiguration _configuration;
-        private readonly HttpClient _client;
+        private readonly IHttpClientFactory _clientFactory;
 
-        public UploadFileProcessingController(IConfiguration configuration, HttpClient client)
+        public UploadFileProcessingController(IConfiguration configuration, IHttpClientFactory clientFactory)
         {
             _configuration = configuration;
-            _client = client;
+            _clientFactory = clientFactory;
         }
 
         [HttpPost]
-        public IActionResult Index([FromBody]List<SchemeParameterTemplateValue> schemeParameterValues)
+        public IActionResult Index([FromBody] List<SchemeParameterTemplateValue> schemeParameterValues)
         {
+
             var parameterSettingsApi = _configuration.GetSection("ParameterSettings").GetSection("DefaultParameterSettingsApi").Value;
 
-            _client.BaseAddress = new Uri(parameterSettingsApi);
+            var client = _clientFactory.CreateClient();
+            client.BaseAddress = new Uri(parameterSettingsApi);
 
             var payload = Transform(schemeParameterValues);
 
@@ -30,7 +32,7 @@ namespace EPR.Calculator.Frontend.Controllers
             var request = new HttpRequestMessage(HttpMethod.Post, new Uri(parameterSettingsApi));
             request.Content = content;
 
-            var response = _client.SendAsync(request);
+            var response = client.SendAsync(request);
 
             response.Wait();
 
@@ -38,7 +40,6 @@ namespace EPR.Calculator.Frontend.Controllers
             {
                 return Ok(response.Result);
             }
-
             return BadRequest(response.Result.Content.ReadAsStringAsync().Result);
         }
 


### PR DESCRIPTION
The code for UploadFileProcessingController and its corresponding test file needs to be refactored to consider IHttpClientFactory instead of HttpClient.