### PR TITLE
Feature/462926 frontend lapcap upload capture filename and store in db 1

### DIFF
--- a/src/EPR.Calculator.Frontend.UnitTests/LocalAuthorityUploadFileControllerTests.cs
+++ b/src/EPR.Calculator.Frontend.UnitTests/LocalAuthorityUploadFileControllerTests.cs
@@ -27,6 +27,7 @@ namespace EPR.Calculator.Frontend.UnitTests
             var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
 
             tempData["FilePath"] = Directory.GetCurrentDirectory() + "/Mocks/LocalAuthorityData.csv";
+            tempData["FileName"] = "LocalAuthorityData.csv";
 
             var controller = new LocalAuthorityUploadFileController()
             {
@@ -36,6 +37,7 @@ namespace EPR.Calculator.Frontend.UnitTests
             var result = await controller.Upload() as ViewResult;
             Assert.IsNotNull(result);
             Assert.AreEqual(ViewNames.LocalAuthorityUploadFileRefresh, result.ViewName);
+            Assert.AreEqual(result.TempData["FileName"].ToString(), "LocalAuthorityData.csv");
         }
 
         [TestMethod]
@@ -54,6 +56,7 @@ namespace EPR.Calculator.Frontend.UnitTests
             var result = await controller.Upload() as ViewResult;
             Assert.IsNotNull(result);
             Assert.AreEqual(ViewNames.LocalAuthorityUploadFileIndex, result.ViewName);
+            Assert.IsNull(result.TempData["FileName"]);
         }
 
         [TestMethod]
@@ -106,6 +109,7 @@ namespace EPR.Calculator.Frontend.UnitTests
             var httpContext = new DefaultHttpContext();
             var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
             tempData[UploadFileErrorIds.LocalAuthorityUploadErrors] = string.Empty;
+            tempData["FileName"] = "LocalAuthorityData.csv";
 
             var controller = new LocalAuthorityUploadFileController()
             {
@@ -126,11 +130,12 @@ namespace EPR.Calculator.Frontend.UnitTests
             writer.Write(content);
             writer.Flush();
             stream.Position = 0;
-            var file = new FormFile(stream, 0, stream.Length, string.Empty, "SchemeParameters.csv");
+            var file = new FormFile(stream, 0, stream.Length, string.Empty, "LocalAuthorityData.csv");
 
             var httpContext = new DefaultHttpContext();
             var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
             tempData[UploadFileErrorIds.LocalAuthorityUploadErrors] = string.Empty;
+            tempData["FileName"] = "LocalAuthorityData.csv";
 
             var controller = new LocalAuthorityUploadFileController()
             {
@@ -151,7 +156,7 @@ namespace EPR.Calculator.Frontend.UnitTests
             writer.Write(content);
             writer.Flush();
             stream.Position = 0;
-            var file = new FormFile(stream, 0, stream.Length, string.Empty, "SchemeParameters.txt");
+            var file = new FormFile(stream, 0, stream.Length, string.Empty, "LocalAuthorityData.txt");
 
             var httpContext = new DefaultHttpContext();
             var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
@@ -176,7 +181,7 @@ namespace EPR.Calculator.Frontend.UnitTests
             writer.Write(content);
             writer.Flush();
             stream.Position = 0;
-            var file = new FormFile(stream, 0, stream.Length, string.Empty, "SchemeParameters.xlsx");
+            var file = new FormFile(stream, 0, stream.Length, string.Empty, "LocalAuthorityData.xlsx");
 
             var httpContext = new DefaultHttpContext();
             var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());

--- a/src/EPR.Calculator.Frontend.UnitTests/LocalAuthorityUploadFileErrorControllerTests.cs
+++ b/src/EPR.Calculator.Frontend.UnitTests/LocalAuthorityUploadFileErrorControllerTests.cs
@@ -99,7 +99,7 @@ namespace EPR.Calculator.Frontend.UnitTests
             writer.Write(content);
             writer.Flush();
             stream.Position = 0;
-            IFormFile file = new FormFile(stream, 0, stream.Length, string.Empty, "SchemeParameters.csv");
+            IFormFile file = new FormFile(stream, 0, stream.Length, string.Empty, "LocalAuthorityData.csv");
 
             var httpContext = new DefaultHttpContext();
             var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
@@ -138,7 +138,7 @@ namespace EPR.Calculator.Frontend.UnitTests
             writer.Write(content);
             writer.Flush();
             stream.Position = 0;
-            IFormFile file = new FormFile(stream, 0, stream.Length, string.Empty, "SchemeParameters.xlsx");
+            IFormFile file = new FormFile(stream, 0, stream.Length, string.Empty, "LocalAuthorityData.xlsx");
 
             var controller = new LocalAuthorityUploadFileErrorController();
             var result = await controller.Upload(file) as ViewResult;
@@ -155,7 +155,7 @@ namespace EPR.Calculator.Frontend.UnitTests
             writer.Write(content);
             writer.Flush();
             stream.Position = 0;
-            IFormFile file = new FormFile(stream, 0, stream.Length, string.Empty, "SchemeParameters.csv");
+            IFormFile file = new FormFile(stream, 0, stream.Length, string.Empty, "LocalAuthorityData.csv");
 
             var httpContext = new DefaultHttpContext();
             var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());

--- a/src/EPR.Calculator.Frontend.UnitTests/LocalAuthorityUploadFileProcessingControllerTests.cs
+++ b/src/EPR.Calculator.Frontend.UnitTests/LocalAuthorityUploadFileProcessingControllerTests.cs
@@ -2,7 +2,9 @@
 using EPR.Calculator.Frontend.Constants;
 using EPR.Calculator.Frontend.Controllers;
 using EPR.Calculator.Frontend.UnitTests.Mocks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Configuration;
 using Moq;
 using Moq.Protected;
@@ -39,13 +41,21 @@ namespace EPR.Calculator.Frontend.UnitTests
                 .Setup(_ => _.CreateClient(It.IsAny<string>()))
                 .Returns(httpClient);
 
+            var httpContext = new DefaultHttpContext();
+            var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
+            tempData["FileName"] = "LocalAuthorityData.csv";
+
             // Create controller with the mocked factory
-            var controller = new LocalAuthorityUploadFileProcessingController(GetConfigurationValues(), mockHttpClientFactory.Object);
+            var controller = new LocalAuthorityUploadFileProcessingController(GetConfigurationValues(), mockHttpClientFactory.Object)
+            {
+                TempData = tempData
+            };
 
             // Act
             var result = controller.Index(MockData.GetLocalAuthorityDisposalCostsToUpload().ToList()) as OkObjectResult;
 
             // Assert
+            Assert.AreEqual("LocalAuthorityData.csv", controller.FileName);
             Assert.IsNotNull(result);
             Assert.AreEqual(200, result.StatusCode);
         }
@@ -67,10 +77,19 @@ namespace EPR.Calculator.Frontend.UnitTests
 
             var httpClient = new HttpClient(mockHttpMessageHandler.Object);
             var mockHttpClientFactory = new Mock<IHttpClientFactory>();
+
+            var httpContext = new DefaultHttpContext();
+            var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
+            tempData["FileName"] = "LocalAuthorityData.csv";
+
             mockHttpClientFactory
                 .Setup(_ => _.CreateClient(It.IsAny<string>()))
                     .Returns(httpClient);
-            var controller = new LocalAuthorityUploadFileProcessingController(GetConfigurationValues(), mockHttpClientFactory.Object);
+
+            var controller = new LocalAuthorityUploadFileProcessingController(GetConfigurationValues(), mockHttpClientFactory.Object)
+            {
+                TempData = tempData
+            };
             var result = controller.Index(MockData.GetLocalAuthorityDisposalCostsToUpload().ToList()) as BadRequestObjectResult;
             Assert.IsNotNull(result);
             Assert.AreNotEqual(201, result.StatusCode);

--- a/src/EPR.Calculator.Frontend/Constants/SessionConstants.cs
+++ b/src/EPR.Calculator.Frontend/Constants/SessionConstants.cs
@@ -3,6 +3,5 @@
     public static class SessionConstants
     {
         public const string CalculationName = "CalculationName";
-        public const string FileName = "FileName";
     }
 }

--- a/src/EPR.Calculator.Frontend/Controllers/LocalAuthorityUploadFileController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/LocalAuthorityUploadFileController.cs
@@ -72,6 +72,7 @@ namespace EPR.Calculator.Frontend.Controllers
             var localAuthorityDisposalCosts = await CsvFileHelper.PrepareLapcapDataForUpload(fileUpload);
 
             this.ViewData["localAuthorityDisposalCosts"] = localAuthorityDisposalCosts.ToArray();
+            this.TempData["FileName"] = fileUpload.FileName;
 
             return ViewNames.LocalAuthorityUploadFileRefresh;
         }

--- a/src/EPR.Calculator.Frontend/Controllers/LocalAuthorityUploadFileErrorController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/LocalAuthorityUploadFileErrorController.cs
@@ -72,6 +72,7 @@ namespace EPR.Calculator.Frontend.Controllers
             var localAuthorityDisposalCostsValues = await CsvFileHelper.PrepareLapcapDataForUpload(fileUpload);
 
             this.ViewData["localAuthorityDisposalCosts"] = localAuthorityDisposalCostsValues.ToArray();
+            this.TempData["FileName"] = fileUpload.FileName;
 
             return this.View(ViewNames.LocalAuthorityUploadFileRefresh);
         }

--- a/src/EPR.Calculator.Frontend/Controllers/LocalAuthorityUploadFileProcessingController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/LocalAuthorityUploadFileProcessingController.cs
@@ -17,6 +17,8 @@ namespace EPR.Calculator.Frontend.Controllers
             this.clientFactory = clientFactory;
         }
 
+        public string FileName { get; set; }
+
         [HttpPost]
         public IActionResult Index([FromBody] List<LapcapDataTemplateValueDto> lapcapDataTemplateValues)
         {
@@ -28,6 +30,8 @@ namespace EPR.Calculator.Frontend.Controllers
                 {
                     throw new ArgumentNullException(lapcapSettingsApi, "LapcapSettingsApi is null. Check the configuration settings for local authority");
                 }
+
+                this.FileName = this.TempData.Peek("FileName").ToString();
 
                 var client = this.clientFactory.CreateClient();
                 client.BaseAddress = new Uri(lapcapSettingsApi);
@@ -68,6 +72,7 @@ namespace EPR.Calculator.Frontend.Controllers
             {
                 ParameterYear = parameterYear,
                 LapcapDataTemplateValues = lapcapDataTemplateValues,
+                LapcapFileName = this.FileName,
             };
 
             return JsonConvert.SerializeObject(lapcapData);

--- a/src/EPR.Calculator.Frontend/Models/CreateLapcapDataDto.cs
+++ b/src/EPR.Calculator.Frontend/Models/CreateLapcapDataDto.cs
@@ -2,13 +2,35 @@
 
 namespace EPR.Calculator.Frontend.Models
 {
+    /// <summary>
+    /// Data Transfer Object (DTO) for creating lapcap parameter settings.
+    /// </summary>
     [ExcludeFromCodeCoverage]
     public class CreateLapcapDataDto
     {
+        /// <summary>
+        /// Gets or sets the parameter year.
+        /// </summary>
+        /// <value>
+        /// The year for which the parameters are set.
+        /// </value>
         public required string ParameterYear { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collection of lapcap parameter template values.
+        /// </summary>
+        /// <value>
+        /// A collection of <see cref="LapcapDataTemplateValueDto"/> objects representing the template values for the lapcap parameters.
+        /// </value>
 
         public required IEnumerable<LapcapDataTemplateValueDto> LapcapDataTemplateValues { get; set; }
 
-        public string FileName { get; set; }
+        /// <summary>
+        /// Gets or sets the parameter fielname.
+        /// </summary>
+        /// <value>
+        /// The filename.
+        /// </value>
+        public required string LapcapFileName { get; set; }
     }
 }


### PR DESCRIPTION
Integration of backend API ticket.
User now able to upload the csv file and name is stored into the db.