### PR TITLE
Spike  - Fix for memory token expiring on application restart locally or in other environments 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /.vs
 /src/EPR.Calculator.Frontend.Common/bin/Release/net8.0
 /src/EPR.Calculator.Frontend.UnitTests/bin/Release/net8.0
+/src/EPR.Calculator.Frontend.Common.UnitTests/bin/Debug/net8.0
+/src/EPR.Calculator.Frontend.Common.UnitTests/obj

--- a/src/EPR.Calculator.Frontend/Controllers/BaseController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/BaseController.cs
@@ -30,7 +30,8 @@ namespace EPR.Calculator.Frontend.Controllers
 #pragma warning restore SA1600
         {
             this.TelemetryClient.TrackTrace("AcquireToken");
-            var token = this.HttpContext?.Session?.GetString("accessToken");
+            string? token = null;
+
             if (string.IsNullOrEmpty(token))
             {
                 try
@@ -46,7 +47,6 @@ namespace EPR.Calculator.Frontend.Controllers
                 }
 
                 this.TelemetryClient.TrackTrace("after generating..");
-                this.HttpContext?.Session?.SetString("accessToken", token);
             }
 
             var accessToken = $"Bearer {token}";

--- a/src/EPR.Calculator.Frontend/EPR.Calculator.Frontend.csproj
+++ b/src/EPR.Calculator.Frontend/EPR.Calculator.Frontend.csproj
@@ -37,6 +37,7 @@
 		<PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="3.5.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="9.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/EPR.Calculator.Frontend/appsettings.json
+++ b/src/EPR.Calculator.Frontend/appsettings.json
@@ -50,7 +50,10 @@
     "ConnectionString": "BlobConnectionString",
     "ContainerName": "BlobDataProtectionContainerName"
   },
-  "SessionCookieName": "SessionName"
-
-
+  "SessionCookieName": "SessionName",
+  "DistributedSqlServerCache": {
+    "ConnectionString": "Copy connection string for the Paycal Database",
+    "TableName": "CacheTable",
+    "DefaultSlidingExpirationInMinutes": 90
+  }
 }


### PR DESCRIPTION
Added distributed cache to store the access token, using sql server, we can redis/cosmos in the future, please don't review or merge the ticket, this is Spike ticket (POC)