### PR TITLE
Bill page 500 error CalculationRunDetailsNew/1

### DIFF
--- a/src/EPR.Calculator.Frontend/Controllers/CalculationRunDetailsNewController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/CalculationRunDetailsNewController.cs
@@ -77,9 +77,6 @@ namespace EPR.Calculator.Frontend.Controllers
 
         private static CalculatorRunDto GetCalculationRunDetails(int runId)
         {
-            // Get the calculation run details from the API
-            var calculatorRuns = new List<CalculatorRunDto>();
-
             CalculatorRunDto calculatorRunDto = new()
             {
                 RunId = runId,

--- a/src/EPR.Calculator.Frontend/Controllers/CalculationRunDetailsNewController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/CalculationRunDetailsNewController.cs
@@ -77,18 +77,6 @@ namespace EPR.Calculator.Frontend.Controllers
 
         private static CalculatorRunDto GetCalculationRunDetails(int runId)
         {
-            CalculatorRunDto calculatorRunDto = new()
-            {
-                RunId = runId,
-                FinancialYear = "2024-25",
-                FileExtension = "xlsx",
-                RunClassificationStatus = "Unclassified",
-                RunName = "Calculation Run 99",
-                RunClassificationId = 3,
-                CreatedAt = new DateTime(2024, 5, 1, 12, 09, 0, DateTimeKind.Utc),
-                CreatedBy = "Steve Jones",
-            };
-
             if (runId == 190508)
             {
                 return new()
@@ -104,7 +92,17 @@ namespace EPR.Calculator.Frontend.Controllers
                 };
             }
 
-            return calculatorRunDto;
+            return new()
+            {
+                RunId = runId,
+                FinancialYear = "2024-25",
+                FileExtension = "xlsx",
+                RunClassificationStatus = "Unclassified",
+                RunName = "Calculation Run 99",
+                RunClassificationId = 3,
+                CreatedAt = new DateTime(2024, 5, 1, 12, 09, 0, DateTimeKind.Utc),
+                CreatedBy = "Steve Jones",
+            };
         }
 
         private static bool IsRunEligibleForDisplay(CalculatorRunDto calculatorRun)

--- a/src/EPR.Calculator.Frontend/Controllers/CalculationRunDetailsNewController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/CalculationRunDetailsNewController.cs
@@ -82,7 +82,7 @@ namespace EPR.Calculator.Frontend.Controllers
 
             CalculatorRunDto calculatorRunDto = new()
             {
-                RunId = 240008,
+                RunId = runId,
                 FinancialYear = "2024-25",
                 FileExtension = "xlsx",
                 RunClassificationStatus = "Unclassified",
@@ -92,23 +92,22 @@ namespace EPR.Calculator.Frontend.Controllers
                 CreatedBy = "Steve Jones",
             };
 
-            CalculatorRunDto calculatorRunErrorDto = new()
+            if (runId == 190508)
             {
-                RunId = 190508,
-                FinancialYear = "2024-25",
-                FileExtension = "xlsx",
-                RunClassificationStatus = "Error",
-                RunName = "Calculation Run 99",
-                RunClassificationId = 5,
-                CreatedAt = new DateTime(2024, 5, 1, 12, 09, 0, DateTimeKind.Utc),
-                CreatedBy = "Steve Jones",
-            };
+                return new()
+                {
+                    RunId = 190508,
+                    FinancialYear = "2024-25",
+                    FileExtension = "xlsx",
+                    RunClassificationStatus = "Error",
+                    RunName = "Calculation Run 99",
+                    RunClassificationId = 5,
+                    CreatedAt = new DateTime(2024, 5, 1, 12, 09, 0, DateTimeKind.Utc),
+                    CreatedBy = "Steve Jones",
+                };
+            }
 
-            calculatorRuns.Add(calculatorRunDto);
-            calculatorRuns.Add(calculatorRunErrorDto);
-            var calculatorRun = calculatorRuns.Where(x => x.RunId == runId).FirstOrDefault();
-
-            return calculatorRun;
+            return calculatorRunDto;
         }
 
         private static bool IsRunEligibleForDisplay(CalculatorRunDto calculatorRun)


### PR DESCRIPTION
As per the bug navigating to CalculationRunDetailsNew/1 was returning an error 500 page to testers.
Upon investigation I found that it was because of hardcoded scenarios a valid dto model was not being returned if the the two hardcoded run ids were not supplied.
In order to get the best of both worlds I have now updated the flow so that should the tester provider the specific error scenario test code of 190508 it will go to the error page but in all other scenarios go to a successful scenario page.