### PR TITLE
Feature/581840 dynamic screen post initialrun classification (#292)

### DIFF
--- a/src/EPR.Calculator.Frontend.UnitTests/Controllers/ClassifyingCalculationRunControllerTests.cs
+++ b/src/EPR.Calculator.Frontend.UnitTests/Controllers/ClassifyingCalculationRunControllerTests.cs
@@ -17,7 +17,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Web;
-using Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Templates.Blazor;
 using Moq;
 using Moq.Protected;
 
@@ -33,6 +32,7 @@ namespace EPR.Calculator.Frontend.UnitTests.Controllers
         private TelemetryClient _mockTelemetryClient;
         private SetRunClassificationController _controller;
         private Mock<HttpContext> _mockHttpContext;
+        private Mock<ICalculatorRunDetailsService> _mockCalculatorRunDetailsService;
 
         public ClassifyingCalculationRunControllerTests()
         {
@@ -43,6 +43,7 @@ namespace EPR.Calculator.Frontend.UnitTests.Controllers
             _mockLogger = new Mock<ILogger<SetRunClassificationController>>();
             _mockTokenAcquisition = new Mock<ITokenAcquisition>();
             _mockTelemetryClient = new TelemetryClient();
+            _mockCalculatorRunDetailsService = new Mock<ICalculatorRunDetailsService>();
 
             _mockTokenAcquisition
                 .Setup(x => x.GetAccessTokenForUserAsync(It.IsAny<IEnumerable<string>>(), null, null, null, null))
@@ -54,7 +55,7 @@ namespace EPR.Calculator.Frontend.UnitTests.Controllers
                        _mockLogger.Object,
                        _mockTokenAcquisition.Object,
                        _mockTelemetryClient,
-                       new Mock<ICalculatorRunDetailsService>().Object);
+                       _mockCalculatorRunDetailsService.Object);
 
             _mockHttpContext = new Mock<HttpContext>();
             _mockHttpContext.Setup(context => context.User)
@@ -458,6 +459,160 @@ namespace EPR.Calculator.Frontend.UnitTests.Controllers
             Assert.IsNotNull(result);
             Assert.AreEqual(ActionNames.Index, result.ActionName);
             Assert.AreEqual(CommonUtil.GetControllerName(typeof(StandardErrorController)), result.ControllerName);
+        }
+
+        [TestMethod]
+        public async Task Index_ReturnsStandardError_WhenRunIdIsZero()
+        {
+            var details = Fixture.Create<CalculatorRunDetailsViewModel>();
+            details.RunId = 0;
+
+            (_, _, _controller) = BuildTestClass(
+                this.Fixture,
+                HttpStatusCode.Created,
+                Fixture.Create<FinancialYearClassificationResponseDto>(),
+                details,
+                _configuration);
+            // Arrange
+            int runId = 1;
+
+            // Act
+            var result = await _controller.Index(runId) as RedirectToActionResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(ActionNames.Index, result.ActionName);
+            Assert.AreEqual(CommonUtil.GetControllerName(typeof(StandardErrorController)), result.ControllerName);
+        }
+
+        [TestMethod]
+
+        [DataRow(RunClassification.INITIAL_RUN, CommonConstants.InitialRunDescription)]
+        [DataRow(RunClassification.TEST_RUN, CommonConstants.TestRunDescription)]
+        [DataRow(RunClassification.INTERIM_RECALCULATION_RUN, CommonConstants.InterimRunDescription)]
+        [DataRow(RunClassification.FINAL_RECALCULATION_RUN, CommonConstants.FinalRecalculationRunDescription)]
+        [DataRow(RunClassification.FINAL_RUN, CommonConstants.FinalRecalculationRunDescription)]
+        public async Task Index_CheckClassificationStatusDescription_IsValid(RunClassification runClassification, string description)
+        {
+            var responseContent = "{\r\n  \"runId\": 1,\r\n  \"runClassificationId\": 7,\r\n  \"runName\": \"Test Calculator1702\",\r\n  \"runClassificationStatus\": \"UNCLASSIFIED\",\r\n  \"financialYear\": \"2025-26\"\r\n}";
+            var classificationResponseContent = "{\r\n\"financialYear\": \"2025-26\",\r\n  \"classifications\": [\r\n    {\r\n      \"id\":" + (int)runClassification + ",\r\n\"status\": \"INITIAL RUN\"\r\n    }\r\n  ]\r\n}";
+
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+
+            mockHttpMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new StringContent(responseContent)
+                    });
+
+            mockHttpMessageHandler
+               .Protected()
+               .Setup<Task<HttpResponseMessage>>(
+                   "SendAsync",
+                   ItExpr.Is<HttpRequestMessage>(k => k.RequestUri != null && k.RequestUri.ToString().Contains("Financial")),
+                   ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                   {
+                       StatusCode = HttpStatusCode.OK,
+                       Content = new StringContent(classificationResponseContent),
+                   });
+
+            // Arrange
+            int runId = 1;
+
+            var details = Fixture.Create<CalculatorRunDetailsViewModel>();
+            details.RunId = runId;
+
+            var financialYearDto = Fixture.Create<FinancialYearClassificationResponseDto>();
+
+            financialYearDto.Classifications = new List<CalculatorRunClassificationDto>
+            {
+                new CalculatorRunClassificationDto
+                {
+                    Id = (int)runClassification,
+                    Description = description,
+                    Status = runClassification.ToString()
+                }
+            };
+
+            (_, _, _controller) = BuildTestClass(
+                this.Fixture,
+                HttpStatusCode.Created,
+                financialYearDto,
+                details,
+                _configuration);
+
+            // Act
+            var result = await _controller.Index(runId) as ViewResult;
+            var model = result.Model as SetRunClassificationViewModel;
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result.Model, typeof(SetRunClassificationViewModel));
+            Assert.AreEqual(description, model.FinancialYearClassifications.Classifications.First().Description);
+        }
+
+        [TestMethod]
+        [DataRow(RunClassification.INITIAL_RUN, CommonConstants.InitialRunDescription)]
+        [DataRow(RunClassification.FINAL_RECALCULATION_RUN, CommonConstants.FinalRecalculationRunDescription)]
+        [DataRow(RunClassification.FINAL_RUN, CommonConstants.FinalRecalculationRunDescription)]
+        public async Task Index_ValidModel_ClassificationStatusInformation_IsValid(RunClassification runClassification, string description)
+        {
+            // Arrange
+            int runId = 1;
+
+            var details = Fixture.Create<CalculatorRunDetailsViewModel>();
+            details.RunId = runId;
+
+            var financialYearDto = Fixture.Create<FinancialYearClassificationResponseDto>();
+
+            financialYearDto.Classifications = new List<CalculatorRunClassificationDto>
+            {
+                new CalculatorRunClassificationDto
+                {
+                    Id = (int)runClassification,
+                    Description = description,
+                    Status = runClassification.ToString()
+                }
+            };
+
+            (_, _, _controller) = BuildTestClass(
+                this.Fixture,
+                HttpStatusCode.Created,
+                financialYearDto,
+                details,
+                _configuration);
+
+            // Act
+            var result = await _controller.Index(runId) as ViewResult;
+            var model = result.Model as SetRunClassificationViewModel;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result.Model, typeof(SetRunClassificationViewModel));
+
+            if(runClassification == RunClassification.INITIAL_RUN)
+            {
+               Assert.IsFalse(model.ClassificationStatusInformation.ShowInitialRunDescription);
+               Assert.IsTrue(model.ClassificationStatusInformation.ShowInterimRecalculationRunDescription);
+               Assert.IsTrue(model.ClassificationStatusInformation.ShowFinalRecalculationRunDescription);
+               Assert.IsTrue(model.ClassificationStatusInformation.ShowFinalRunDescription);
+            }
+
+            if (runClassification == RunClassification.FINAL_RECALCULATION_RUN)
+            {
+                Assert.IsTrue(model.ClassificationStatusInformation.ShowInitialRunDescription);
+                Assert.IsFalse(model.ClassificationStatusInformation.ShowFinalRecalculationRunDescription);
+            }
+
+            if (runClassification == RunClassification.FINAL_RUN)
+            {
+                Assert.IsTrue(model.ClassificationStatusInformation.ShowInitialRunDescription);
+                Assert.IsFalse(model.ClassificationStatusInformation.ShowFinalRunDescription);
+            }
         }
 
         private void SetMessageHandlerResponses(bool isUnclassified, HttpStatusCode httpStatusCode)

--- a/src/EPR.Calculator.Frontend/Constants/ClassifyCalculationRunStatusInformation.cs
+++ b/src/EPR.Calculator.Frontend/Constants/ClassifyCalculationRunStatusInformation.cs
@@ -1,0 +1,10 @@
+﻿namespace EPR.Calculator.Frontend.Constants
+{
+    public static class ClassifyCalculationRunStatusInformation
+    {
+        public const string RunStatusDescription = "Already classified for financial year {0} on Date Info.";
+        public const string InterimReCalculationStatusDescription = "An optional run, only available after the initial run.";
+        public const string FinalRecalculationStatusDescription = "An optional run, only available if no other final recalculation or later run has been classified this year.";
+        public const string FinalRunStatusDescription = "A mandatory run, only available if no other final run or later run has been classified this year.";
+    }
+}

--- a/src/EPR.Calculator.Frontend/Constants/CommonConstants.cs
+++ b/src/EPR.Calculator.Frontend/Constants/CommonConstants.cs
@@ -12,8 +12,18 @@
         public const string DateFormat = "dd MMM yyyy";
         public const string TimeFormat = "H:mm";
         public const string RunDetailError = "The calculation was unsuccessful";
+
+        public const string InitialRunStatus = "Initial run";
+        public const string TestRunStatus = "Test run";
+        public const string InterimRunStatus = "Interim recalculation run";
+        public const string FinalRecalculationRunStatus = "Final recalculation run";
+        public const string FinalRunStatus = "Final run";
+
         public const string InitialRunDescription = "The first official mandatory run of the financial year, used as the baseline for all future recalculations. This run generates an initial billing file for invoicing.";
         public const string TestRunDescription = "An unofficial run to view the calculation results without generating a billing file for invoicing.";
+        public const string InterimRunDescription = "An official, optional run that can happen any time after the initial run, including after final runs. It can be run multiple times and generate a billing file. It can be used to process late or updated producer data.";
+        public const string FinalRecalculationRunDescription = "An official, optional run using corrected data. It can produce a billing file for invoicing and is expected to be the last recalculation.";
+        public const string FinalRunDescription = "An official, mandatory run at the end of the financial year that can produce a billing file for invoicing. Corrections after this must use the interim recalculation classification.";
 
         public const bool IsDraftFileTrue = true;
         public const bool IsDraftFileFalse = false;

--- a/src/EPR.Calculator.Frontend/Controllers/CalculationRunDetailsNewController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/CalculationRunDetailsNewController.cs
@@ -1,8 +1,6 @@
-﻿using EPR.Calculator.Frontend.Common.Constants;
-using EPR.Calculator.Frontend.Constants;
+﻿using EPR.Calculator.Frontend.Constants;
 using EPR.Calculator.Frontend.Enums;
 using EPR.Calculator.Frontend.Helpers;
-using EPR.Calculator.Frontend.Models;
 using EPR.Calculator.Frontend.Services;
 using EPR.Calculator.Frontend.ViewModels;
 using EPR.Calculator.Frontend.ViewModels.Enums;
@@ -16,23 +14,16 @@ namespace EPR.Calculator.Frontend.Controllers
     /// Controller responsible for displaying the details of a calculation run.
     /// </summary>
     [Route("[controller]")]
-    public class CalculationRunDetailsNewController : BaseController
+    public class CalculationRunDetailsNewController(IConfiguration configuration,
+           IApiService apiService,
+           ITokenAcquisition tokenAcquisition,
+           TelemetryClient telemetryClient,
+           ICalculatorRunDetailsService calculatorRunDetailsService) : BaseController(configuration,
+                 tokenAcquisition,
+                 telemetryClient,
+                 apiService,
+                 calculatorRunDetailsService)
     {
-        public CalculationRunDetailsNewController(
-            IConfiguration configuration,
-            IApiService apiService,
-            ITokenAcquisition tokenAcquisition,
-            TelemetryClient telemetryClient,
-            ICalculatorRunDetailsService calculatorRunDetailsService)
-            : base(
-                  configuration,
-                  tokenAcquisition,
-                  telemetryClient,
-                  apiService,
-                  calculatorRunDetailsService)
-        {
-        }
-
         [Route("{runId}")]
         public async Task<IActionResult> Index(int runId)
         {

--- a/src/EPR.Calculator.Frontend/Controllers/SetRunClassificationController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/SetRunClassificationController.cs
@@ -3,6 +3,7 @@ using System.Net;
 using EPR.Calculator.Frontend.Common.Constants;
 using EPR.Calculator.Frontend.Constants;
 using EPR.Calculator.Frontend.Enums;
+using EPR.Calculator.Frontend.Extensions;
 using EPR.Calculator.Frontend.Helpers;
 using EPR.Calculator.Frontend.Models;
 using EPR.Calculator.Frontend.Services;
@@ -46,7 +47,7 @@ namespace EPR.Calculator.Frontend.Controllers
             try
             {
                 var viewModel = await this.CreateViewModel(runId);
-                if (!await SetClassfications(runId, viewModel))
+                if (!await this.SetClassifications(runId, viewModel))
                 {
                     return this.RedirectToAction(ActionNames.StandardErrorIndex, CommonUtil.GetControllerName(typeof(StandardErrorController)));
                 }
@@ -80,7 +81,7 @@ namespace EPR.Calculator.Frontend.Controllers
                 if (!this.ModelState.IsValid)
                 {
                     var viewModel = await this.CreateViewModel(model.CalculatorRunDetails.RunId);
-                    await this.SetClassfications(model.CalculatorRunDetails.RunId, viewModel);
+                    await this.SetClassifications(model.CalculatorRunDetails.RunId, viewModel);
 
                     return this.View(ViewNames.SetRunClassificationIndex, viewModel);
                 }
@@ -157,11 +158,10 @@ namespace EPR.Calculator.Frontend.Controllers
 
         private void SetStatusDescriptions(SetRunClassificationViewModel model)
         {
-            TextInfo myTI = new CultureInfo("en-GB", false).TextInfo;
             foreach (var classification in model.FinancialYearClassifications.Classifications)
             {
-                classification.Description = GetStatusDescription(classification.Id);
-                classification.Status = myTI.ToTitleCase(classification.Status.ToLower());
+                classification.Description = this.GetStatusDescription(classification.Id);
+                classification.Status = this.GetStatus(classification);
             }
         }
 
@@ -169,13 +169,30 @@ namespace EPR.Calculator.Frontend.Controllers
         {
             return classificationId switch
             {
-               (int)RunClassification.INITIAL_RUN => CommonConstants.InitialRunDescription,
+                (int)RunClassification.INITIAL_RUN => CommonConstants.InitialRunDescription,
                 (int)RunClassification.TEST_RUN => CommonConstants.TestRunDescription,
+                (int)RunClassification.INTERIM_RECALCULATION_RUN => CommonConstants.InterimRunDescription,
+                (int)RunClassification.FINAL_RECALCULATION_RUN => CommonConstants.FinalRecalculationRunDescription,
+                (int)RunClassification.FINAL_RUN => CommonConstants.FinalRecalculationRunDescription,
                 _ => string.Empty,
             };
         }
 
-        private async Task<bool> SetClassfications(int runId, SetRunClassificationViewModel viewModel)
+        private string GetStatus(CalculatorRunClassificationDto classificationDto)
+        {
+            TextInfo myTI = new CultureInfo("en-GB", false).TextInfo;
+            return classificationDto.Id switch
+            {
+                (int)RunClassification.INITIAL_RUN => CommonConstants.InitialRunStatus,
+                (int)RunClassification.TEST_RUN => CommonConstants.TestRunStatus,
+                (int)RunClassification.INTERIM_RECALCULATION_RUN => CommonConstants.InterimRunStatus,
+                (int)RunClassification.FINAL_RECALCULATION_RUN => CommonConstants.FinalRecalculationRunStatus,
+                (int)RunClassification.FINAL_RUN => CommonConstants.FinalRunStatus,
+                _ => myTI.ToFirstLetterCap(classificationDto.Status),
+            };
+        }
+
+        private async Task<bool> SetClassifications(int runId, SetRunClassificationViewModel viewModel)
         {
             var classifications = await this.GetClassfications(new CalcFinancialYearRequestDto() { RunId = runId, FinancialYear = CommonUtil.GetFinancialYear(this.HttpContext.Session) });
             if (!classifications.IsSuccessStatusCode)
@@ -185,7 +202,57 @@ namespace EPR.Calculator.Frontend.Controllers
 
             viewModel.FinancialYearClassifications = JsonConvert.DeserializeObject<FinancialYearClassificationResponseDto>(classifications.Content.ReadAsStringAsync().Result);
             this.SetStatusDescriptions(viewModel);
+
+            if (viewModel.FinancialYearClassifications != null)
+            {
+                viewModel.ClassificationStatusInformation = this.GetClassificationStatusInformation(viewModel.FinancialYearClassifications.Classifications);
+            }
+
             return true;
+        }
+
+        private ClassificationStatusInformationViewModel GetClassificationStatusInformation(List<CalculatorRunClassificationDto> classificationList)
+        {
+            ClassificationStatusInformationViewModel classificationStatusInformationViewModel = new ClassificationStatusInformationViewModel();
+
+            if (classificationList != null && classificationList.Count > 0)
+            {
+                string financialYear = CommonUtil.GetFinancialYear(this.HttpContext.Session);
+
+                // check if calculator classification list have initial run
+                if (classificationList.Exists(n => n.Id == (int)RunClassification.INITIAL_RUN))
+                {
+                    classificationStatusInformationViewModel.ShowInterimRecalculationRunDescription = true;
+                    classificationStatusInformationViewModel.InterimRecalculationRunDescription = ClassifyCalculationRunStatusInformation.InterimReCalculationStatusDescription;
+
+                    classificationStatusInformationViewModel.ShowFinalRecalculationRunDescription = true;
+                    classificationStatusInformationViewModel.FinalRecalculationRunDescription = ClassifyCalculationRunStatusInformation.FinalRecalculationStatusDescription;
+
+                    classificationStatusInformationViewModel.ShowFinalRunDescription = true;
+                    classificationStatusInformationViewModel.FinalRunDescription = ClassifyCalculationRunStatusInformation.FinalRunStatusDescription;
+                }
+                else
+                {
+                    classificationStatusInformationViewModel.ShowInitialRunDescription = true;
+                    classificationStatusInformationViewModel.InitialRunDescription = string.Format(ClassifyCalculationRunStatusInformation.RunStatusDescription, financialYear);
+
+                    // check if calculator classification list does not have final recalculation run status to be initiated
+                    if (!classificationList.Exists(n => n.Id == (int)RunClassification.FINAL_RECALCULATION_RUN))
+                    {
+                        classificationStatusInformationViewModel.ShowFinalRecalculationRunDescription = true;
+                        classificationStatusInformationViewModel.FinalRecalculationRunDescription = $"{string.Format(ClassifyCalculationRunStatusInformation.RunStatusDescription, financialYear)}";
+                    }
+
+                    // check if list doesn't have initial run status
+                    if (!classificationList.Exists(n => n.Id == (int)RunClassification.FINAL_RUN))
+                    {
+                        classificationStatusInformationViewModel.ShowFinalRunDescription = true;
+                        classificationStatusInformationViewModel.FinalRunDescription = $"{string.Format(ClassifyCalculationRunStatusInformation.RunStatusDescription, financialYear)}";
+                    }
+                }
+            }
+
+            return classificationStatusInformationViewModel;
         }
     }
 }

--- a/src/EPR.Calculator.Frontend/Enums/RunClassification.cs
+++ b/src/EPR.Calculator.Frontend/Enums/RunClassification.cs
@@ -50,5 +50,23 @@ namespace EPR.Calculator.Frontend.Enums
         [Description("FINAL RECALCULATION RUN CLASSIFIED")]
         [EnumMember(Value = "FINAL RE-CALCULATION RUN")]
         FINAL_RECALCULATION_RUN = 11,
+
+        /// <summary>
+        /// INTERIM RE-CALCULATION RUN COMPLETED.
+        /// </summary>
+        [Description("INTERIM RE-CALCULATION RUN COMPLETED")]
+        INTERIM_RECALCULATION_RUN_COMPLETED = 12,
+
+        /// <summary>
+        /// FINAL RE-CALCULATION RUN COMPLETED.
+        /// </summary>
+        [Description("FINAL RE-CALCULATION RUN COMPLETED")]
+        FINAL_RECALCULATION_RUN_COMPLETED = 13,
+
+        /// <summary>
+        /// FINAL RUN COMPLETED.
+        /// </summary>
+        [Description("FINAL RUN COMPLETED")]
+        FINAL_RUN_COMPLETED = 14,
     }
 }

--- a/src/EPR.Calculator.Frontend/Extensions/TextInfoExtension.cs
+++ b/src/EPR.Calculator.Frontend/Extensions/TextInfoExtension.cs
@@ -1,0 +1,20 @@
+﻿using System.Globalization;
+
+namespace EPR.Calculator.Frontend.Extensions
+{
+    public static class TextInfoExtension
+    {
+        public static string ToFirstLetterCap(this TextInfo textInfo, string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return text;
+            }
+
+            string lowercaseText = textInfo.ToLower(text);
+            char firstChar = textInfo.ToUpper(lowercaseText[0].ToString())[0];
+
+            return firstChar + lowercaseText.Substring(1);
+        }
+    }
+}

--- a/src/EPR.Calculator.Frontend/ViewModels/ClassificationStatusInformationViewModel.cs
+++ b/src/EPR.Calculator.Frontend/ViewModels/ClassificationStatusInformationViewModel.cs
@@ -1,0 +1,53 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace EPR.Calculator.Frontend.ViewModels
+{
+    /// <summary>
+    /// calculation run classification status information view model.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public record ClassificationStatusInformationViewModel
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets show initial run status description.
+        /// </summary>
+        public bool ShowInitialRunDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets show initial run status description.
+        /// </summary>
+        public string? InitialRunDescription { get; set; }
+
+        /// <summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets show interim recalculation run status description.
+        /// </summary>
+        public bool ShowInterimRecalculationRunDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets show interim recalculation run status description.
+        /// </summary>
+        public string? InterimRecalculationRunDescription { get; set; }
+
+        /// <summary>
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets show final recalculation run status description.
+        /// </summary>
+        public bool ShowFinalRecalculationRunDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets final recalculation run status description.
+        /// </summary>
+        public string? FinalRecalculationRunDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets show final run description.
+        /// </summary>
+        public bool ShowFinalRunDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets final run status description.
+        /// </summary>
+        public string? FinalRunDescription { get; set; }
+    }
+}

--- a/src/EPR.Calculator.Frontend/ViewModels/SetRunClassificationViewModel.cs
+++ b/src/EPR.Calculator.Frontend/ViewModels/SetRunClassificationViewModel.cs
@@ -1,14 +1,12 @@
 ﻿using EPR.Calculator.Frontend.Constants;
-using EPR.Calculator.Frontend.Enums;
 using EPR.Calculator.Frontend.Models;
-using EPR.Calculator.Frontend.ViewModels.Enums;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EPR.Calculator.Frontend.ViewModels
 {
     /// <summary>
-    /// classify calculation run scenerio1 view model.
+    /// classify calculation run scenerio view model.
     /// </summary>
     [ExcludeFromCodeCoverage]
     public record SetRunClassificationViewModel : ViewModelCommonData
@@ -19,11 +17,16 @@ namespace EPR.Calculator.Frontend.ViewModels
         public required CalculatorRunDetailsViewModel CalculatorRunDetails { get; set; }
 
         /// <summary>
-        /// Gets or sets the calssify run type.
+        /// Gets or sets the classify run type.
         /// </summary>
         [Required(ErrorMessage = ErrorMessages.ClassifyRunTypeNotSelected)]
         public int? ClassifyRunType { get; set; }
 
         public FinancialYearClassificationResponseDto? FinancialYearClassifications { get; set; }
+
+        /// <summary>
+        /// Gets or sets the classification status information toggles.
+        /// </summary>
+        public ClassificationStatusInformationViewModel? ClassificationStatusInformation { get; set; }
     }
 }

--- a/src/EPR.Calculator.Frontend/Views/SetRunClassification/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/SetRunClassification/Index.cshtml
@@ -4,15 +4,14 @@
 @model SetRunClassificationViewModel
 @{
     var calcDetails = Model.CalculatorRunDetails;
+    var classificationStatusInformation = Model.ClassificationStatusInformation;
 
     var backLinkModel = new BackLinkPartialViewModel
-            {
-                BackLink = Model.BackLink,
-                CurrentUser = Model.CurrentUser,
-                RunId = calcDetails.RunId
-            };
-
-  
+    {
+        BackLink = Model.BackLink,
+        CurrentUser = Model.CurrentUser,
+        RunId = calcDetails.RunId
+    };  
 }
 <script src="~/lib/jquery/dist/jquery.min.js"></script>
 <script src="~/js/common.js"></script>
@@ -64,17 +63,20 @@
                                 @Html.ValidationMessageFor(model => model.ClassifyRunType, "", new { @class = "govuk-error-message" })
 
                                 <div class="govuk-radios" data-module="govuk-radios">
-                                    @foreach (var classfication in Model.FinancialYearClassifications.Classifications.OrderBy(t => t.Status))
+                                    @if(Model.FinancialYearClassifications?.Classifications != null && Model.FinancialYearClassifications.Classifications.Any())
                                     {
-                                    <div class="govuk-radios__item">                                            
-                                            @Html.RadioButtonFor(model => model.ClassifyRunType, classfication.Id, new { @class = "govuk-radios__input", id = classfication.Status })
-                                        <label class="govuk-label govuk-radios__label" for="@classfication.Status">
-                                                <strong>@classfication.Status</strong><br />
-                                            <p class="govuk-body-s" style="margin-bottom: 0;">
-                                                    @classfication.Description
-                                            </p>
-                                        </label>
-                                    </div>   
+                                        @foreach (var classfication in Model.FinancialYearClassifications.Classifications)
+                                        {  
+                                          <div class="govuk-radios__item">                                            
+                                                @Html.RadioButtonFor(model => model.ClassifyRunType, classfication.Id, new { @class = "govuk-radios__input", id = classfication.Status })
+                                            <label class="govuk-label govuk-radios__label" for="@classfication.Status">
+                                                    <strong>@classfication.Status</strong><br />
+                                                <p class="govuk-body-s" style="margin-bottom: 0;">
+                                                        @classfication.Description
+                                                </p>
+                                            </label>
+                                          </div>   
+                                        }
                                     }
                                 </div>
                             </fieldset>
@@ -89,18 +91,37 @@
                             </h2>
                         </div>
                         <div class="govuk-notification-banner__content">
-                            <p class="govuk-body-s">
-                                <strong>Interim recalculation run</strong><br />
-                                An optional run, only available after the initial run.
-                            </p>
-                            <p class="govuk-body-s">
-                                <strong>Final recalculation run</strong><br />
-                                An optional run, only available if no other final recalculation or later run has been classified this year.
-                            </p>
-                            <p class="govuk-body-s">
-                                <strong>Final run</strong><br />
-                                A mandatory run, only available if no other final run or later run has been classified this year.
-                            </p>
+                            @if (classificationStatusInformation != null)
+                            {
+                                @if (classificationStatusInformation.ShowInitialRunDescription)
+                                {
+                                    <p class="govuk-body-s">
+                                        <strong>Initial run</strong><br />
+                                        @classificationStatusInformation.InitialRunDescription
+                                    </p>
+                                }
+                                @if (classificationStatusInformation.ShowInterimRecalculationRunDescription)
+                                {
+                                    <p class="govuk-body-s">
+                                        <strong>Interim recalculation run</strong><br />
+                                        @classificationStatusInformation.InterimRecalculationRunDescription
+                                    </p>
+                                }                           
+                                @if (classificationStatusInformation.ShowFinalRecalculationRunDescription)
+                                {
+                                    <p class="govuk-body-s">
+                                        <strong>Final recalculation run</strong><br />
+                                        @classificationStatusInformation.FinalRecalculationRunDescription
+                                    </p>
+                                }
+                                @if (classificationStatusInformation.ShowFinalRunDescription)
+                                {
+                                    <p class="govuk-body-s">
+                                        <strong>Final run</strong><br />
+                                        @classificationStatusInformation.FinalRunDescription
+                                    </p>
+                                }
+                            }
                         </div>
                     </div>
                     <div class="govuk-warning-text">


### PR DESCRIPTION
* Added business logic for showing important information based on choices available for classifying the calculator run

* updated ordering of enum of  final-recalculation completed and final-run completed, updated importan messages text for different classify status

* fixed typo "RundId" to "RunId" in query param

* updated info to get if final or final recalc already ran

* made propety nullable

* Updated important calculator run logic information text as found in PR review

* fixed sonar qube issue, deference a possible null

* fixed sonar qube issue

* Added unit tests for set classification status description (which was missing from earlier code) and information

* Code review, remove order by status, get default ordering from Api

* merge back post initlal branch and fixed  unit tests

* removed unused config properties

* fixed dereference of possible null reference

* fixed null reference check

* Fix for select all with filter (#298)

* Feature/fix sonar issues in main (#301)

* Sonar Issues

* SonarQube Issue

* SonarQube Issues

---------



* Feature/fix sonar issues in main (#302)

* Sonar Issues

* SonarQube Issue

* SonarQube Issues

* Removed duplicate selecetors

---------



* Fix ammend button (#300)



* resolve conflicts

* Fixes the text issues

* fix sonar issue

* fix sonar issues

---------