### PR TITLE
Updated gulpfile to allow for spinner to correctly be copied over

### DIFF
--- a/src/EPR.Calculator.Frontend/Views/Shared/_Layout.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/Shared/_Layout.cshtml
@@ -63,7 +63,7 @@
     <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag" style="Color: #ffffff;background-color: #1d70b8;">
-                <b>BETA</b>
+                <b>Beta</b>
             </strong>
             <span class="govuk-phase-banner__text">
                 This is a new service - your <a href="#" class="govuk-link:link">feedback</a> will help us improve it.

--- a/src/EPR.Calculator.Frontend/assets/css/styles.css
+++ b/src/EPR.Calculator.Frontend/assets/css/styles.css
@@ -14,6 +14,10 @@
     }
 }
 
+.govuk-tag {
+    max-width: inherit !important;
+}
+
 .dashboard-page {
     .tile-group {
         .tile {

--- a/src/EPR.Calculator.Frontend/gulpfile.js
+++ b/src/EPR.Calculator.Frontend/gulpfile.js
@@ -44,7 +44,7 @@ gulp.task('copy-images', function () {
     gulp.src(path.join(paths.govuk, 'assets/images/*'))
         .pipe(gulp.dest('wwwroot/images', { overwrite: true }));
 
-    return gulp.src(path.join(paths.images, '**/*'))
+    return gulp.src(path.join(paths.images, '**/*'), {encoding:false})
         .pipe(gulp.dest('wwwroot/images', { overwrite: true }));
 });
 


### PR DESCRIPTION
Added override for govuk-tag to not wrap

Update phase banner text to be correct case