### PR TITLE
ECV-635/636 Separate calculator run search from ID lookup

### DIFF
--- a/src/EPR.Calculator.Frontend.UnitTests/Controllers/CalculationRunNameControllerTests.cs
+++ b/src/EPR.Calculator.Frontend.UnitTests/Controllers/CalculationRunNameControllerTests.cs
@@ -91,7 +91,7 @@ public class CalculationRunNameControllerTests
         Assert.IsNotNull(returnedModel.Errors);
         Assert.AreEqual(ViewControlNames.CalculationRunName, returnedModel.Errors.DOMElementId);
         Assert.AreEqual(ErrorMessages.CalculationRunNameEmpty, returnedModel.Errors.ErrorMessage);
-        apiService.Verify(service => service.GetCalculatorRun(It.IsAny<string>()), Times.Never);
+        apiService.Verify(service => service.CheckIfRunNameExists(It.IsAny<string>()), Times.Never);
     }
 
     [TestMethod]
@@ -100,8 +100,8 @@ public class CalculationRunNameControllerTests
         // Arrange
         var calculationName = "Existing Calculation";
         apiService
-            .Setup(service => service.GetCalculatorRun(calculationName))
-            .ReturnsAsync(BuildExistingRun(calculationName));
+            .Setup(service => service.CheckIfRunNameExists(calculationName))
+            .ReturnsAsync(true);
         var controller = BuildController();
         var model = BuildModel(calculationName);
 
@@ -132,8 +132,8 @@ public class CalculationRunNameControllerTests
         CreateCalculatorRunDto? capturedCreateRunDto = null;
 
         apiService
-            .Setup(service => service.GetCalculatorRun(trimmedName))
-            .ReturnsAsync((CalculatorRunDto?)null);
+            .Setup(service => service.CheckIfRunNameExists(trimmedName))
+            .ReturnsAsync(false);
 
         apiService
             .Setup(service => service.CallApi(
@@ -153,7 +153,7 @@ public class CalculationRunNameControllerTests
         // Assert
         Assert.IsNotNull(result);
         Assert.AreEqual(ActionNames.RunCalculatorConfirmation, result.ActionName);
-        apiService.Verify(service => service.GetCalculatorRun(trimmedName), Times.Once);
+        apiService.Verify(service => service.CheckIfRunNameExists(trimmedName), Times.Once);
         apiService.Verify(service => service.CallApi(
             HttpMethod.Post,
             "v1/calculatorRun",
@@ -389,8 +389,8 @@ public class CalculationRunNameControllerTests
     private void SetupUniqueNameScenario(string calculationName, HttpResponseMessage createResponse)
     {
         apiService
-            .Setup(service => service.GetCalculatorRun(calculationName))
-            .ReturnsAsync((CalculatorRunDto?)null);
+            .Setup(service => service.CheckIfRunNameExists(calculationName))
+            .ReturnsAsync(false);
 
         apiService
             .Setup(service => service.CallApi(

--- a/src/EPR.Calculator.Frontend.UnitTests/Services/EprCalculatorApiServiceTests.cs
+++ b/src/EPR.Calculator.Frontend.UnitTests/Services/EprCalculatorApiServiceTests.cs
@@ -245,15 +245,11 @@ public class EprCalculatorApiServiceTests
         // Assert
         CollectionAssert.AreEqual(new[] { 1, 2 }, result.Select(run => run.RunId).ToArray());
         Assert.IsNotNull(_messageHandler.LastRequest);
-        Assert.AreEqual(HttpMethod.Post, _messageHandler.LastRequest!.Method);
+        Assert.AreEqual(HttpMethod.Get, _messageHandler.LastRequest!.Method);
         Assert.AreEqual("/v1/calculatorRuns", _messageHandler.LastRequest.RequestUri?.AbsolutePath);
 
-        var requestBodyJson = await _messageHandler.LastRequest.Content!.ReadAsStringAsync();
-        var requestBody = JsonSerializer.Deserialize<FindCalculatorRunsRequestBody>(
-            requestBodyJson,
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-        Assert.IsNotNull(requestBody);
-        Assert.AreEqual(2026, requestBody.RelativeYear);
+        var query = QueryHelpers.ParseQuery(_messageHandler.LastRequest.RequestUri!.Query);
+        Assert.AreEqual(relativeYear.ToString(), query["relativeYear"].ToString());
     }
 
     [TestMethod]

--- a/src/EPR.Calculator.Frontend.UnitTests/Services/EprCalculatorApiServiceTests.cs
+++ b/src/EPR.Calculator.Frontend.UnitTests/Services/EprCalculatorApiServiceTests.cs
@@ -162,23 +162,6 @@ public class EprCalculatorApiServiceTests
     }
 
     [TestMethod]
-    public async Task GetCalculatorRun_EncodesRunNameBeforeCallingApi()
-    {
-        // Arrange
-        const string runName = "My Run / 2026";
-        var expectedPath = $"/v1/calculatorRuns/{Uri.EscapeDataString(runName)}";
-        _messageHandler.ResponseFactory = _ => new HttpResponseMessage(HttpStatusCode.BadRequest);
-
-        // Act
-        var result = await _service.GetCalculatorRun(runName);
-
-        // Assert
-        Assert.IsNull(result);
-        Assert.IsNotNull(_messageHandler.LastRequest);
-        Assert.AreEqual(expectedPath, _messageHandler.LastRequest!.RequestUri?.AbsolutePath);
-    }
-
-    [TestMethod]
     public async Task DeleteCalculatorRun_Throws_WhenApiReturnsFailure()
     {
         // Arrange
@@ -263,6 +246,43 @@ public class EprCalculatorApiServiceTests
 
         // Assert
         Assert.AreEqual(0, result.Count);
+    }
+
+    [TestMethod]
+    public async Task CheckIfRunNameExists_True_WhenFound()
+    {
+        // Arrange
+        var expectedRuns = new[]
+        {
+            new CalculatorRunDto { RunId = 1, RunName = "run-1" }
+        };
+        _messageHandler.ResponseFactory = _ => JsonResponse(HttpStatusCode.OK, expectedRuns);
+
+        // Act
+        var runExists = await _service.CheckIfRunNameExists("run-1");
+
+        // Assert
+        Assert.IsTrue(runExists);
+        Assert.IsNotNull(_messageHandler.LastRequest);
+        Assert.AreEqual(HttpMethod.Get, _messageHandler.LastRequest!.Method);
+        Assert.AreEqual("/v1/calculatorRuns", _messageHandler.LastRequest.RequestUri?.AbsolutePath);
+
+        var query = QueryHelpers.ParseQuery(_messageHandler.LastRequest.RequestUri!.Query);
+        Assert.AreEqual("run-1", query["runName"].ToString());
+    }
+
+    [TestMethod]
+    public async Task CheckIfRunNameExists_False_WhenNotFound()
+    {
+        // Arrange
+        var expectedRuns = new List<CalculatorRunDto>();
+        _messageHandler.ResponseFactory = _ => JsonResponse(HttpStatusCode.OK, expectedRuns);
+
+        // Act
+        var runExists = await _service.CheckIfRunNameExists("run-1");
+
+        // Assert
+        Assert.IsFalse(runExists);
     }
 
     [TestMethod]

--- a/src/EPR.Calculator.Frontend/Controllers/CalculationRunNameController.cs
+++ b/src/EPR.Calculator.Frontend/Controllers/CalculationRunNameController.cs
@@ -44,9 +44,9 @@ public class CalculationRunNameController(
         if (!string.IsNullOrEmpty(calculationRunModel.CalculationName))
         {
             var calculationName = calculationRunModel.CalculationName.Trim();
-            var runDto = await eprCalculatorApiService.GetCalculatorRun(calculationName);
+            var alreadyExists = await eprCalculatorApiService.CheckIfRunNameExists(calculationName);
 
-            if (runDto != null)
+            if (alreadyExists)
                 return View(ViewNames.CalculationRunNameIndex, CreateViewModel(CreateErrorViewModel(ErrorMessages.CalculationRunNameExists)));
 
             var response = await HttpPostToCalculatorRunApi(calculationName);

--- a/src/EPR.Calculator.Frontend/Services/EprCalculatorApiService.cs
+++ b/src/EPR.Calculator.Frontend/Services/EprCalculatorApiService.cs
@@ -12,7 +12,7 @@ public interface IEprCalculatorApiService
 {
     Task<HttpResponseMessage> CallApi(HttpMethod httpMethod, string relativePath, IDictionary<string, string?>? queryParams = null, object? body = null);
     Task<CalculatorRunDto?> GetCalculatorRun(int runId);
-    Task<CalculatorRunDto?> GetCalculatorRun(string runName);
+    Task<Boolean> CheckIfRunNameExists(string runName);
     Task<List<CalculatorRunDto>> FindCalculatorRuns(RelativeYear relativeYear);
     Task<List<RelativeYear>> FindRelativeYears();
     Task DeleteCalculatorRun(int runId);
@@ -55,10 +55,22 @@ public class EprCalculatorApiService(
         return Get<CalculatorRunDto>($"v1/calculatorRuns/{runId}");
     }
 
-    public Task<CalculatorRunDto?> GetCalculatorRun(string runName)
+    public async Task<bool> CheckIfRunNameExists(string runName)
     {
-        var encodedRunName = Uri.EscapeDataString(runName);
-        return Get<CalculatorRunDto>($"v1/calculatorRuns/{encodedRunName}");
+        var response = await CallApi(
+            HttpMethod.Get,
+            "v1/calculatorRuns",
+            queryParams: new Dictionary<string, string?>
+            {
+                ["runName"] = runName
+            });
+
+        response.EnsureSuccessStatusCode();
+
+        var calculatorRuns =
+            await response.Content.ReadFromJsonAsync<List<CalculatorRunDto>>() ?? [];
+
+        return calculatorRuns.Count > 0;
     }
 
     public async Task<List<CalculatorRunDto>> FindCalculatorRuns(RelativeYear relativeYear)
@@ -66,7 +78,7 @@ public class EprCalculatorApiService(
         var response = await CallApi(
             HttpMethod.Get,
             "v1/calculatorRuns",
-            queryParams: new Dictionary<string, string?> { ["relativeYear"] = relativeYear.ToString() }) ;
+            queryParams: new Dictionary<string, string?> { ["relativeYear"] = relativeYear.ToString() });
 
         if (response.IsSuccessStatusCode)
             return await response.Content.ReadFromJsonAsync<List<CalculatorRunDto>>() ?? [];

--- a/src/EPR.Calculator.Frontend/Services/EprCalculatorApiService.cs
+++ b/src/EPR.Calculator.Frontend/Services/EprCalculatorApiService.cs
@@ -64,9 +64,9 @@ public class EprCalculatorApiService(
     public async Task<List<CalculatorRunDto>> FindCalculatorRuns(RelativeYear relativeYear)
     {
         var response = await CallApi(
-            HttpMethod.Post,
+            HttpMethod.Get,
             "v1/calculatorRuns",
-            body: new { RelativeYear = relativeYear });
+            queryParams: new Dictionary<string, string?> { ["relativeYear"] = relativeYear.ToString() }) ;
 
         if (response.IsSuccessStatusCode)
             return await response.Content.ReadFromJsonAsync<List<CalculatorRunDto>>() ?? [];

--- a/src/EPR.Calculator.Frontend/Validators/CalculatorRunNameValidator.cs
+++ b/src/EPR.Calculator.Frontend/Validators/CalculatorRunNameValidator.cs
@@ -14,10 +14,10 @@ public partial class CalculatorRunNameValidator : AbstractValidator<InitiateCalc
             .WithMessage(ErrorMessages.CalculationRunNameEmpty)
             .MaximumLength(100)
             .WithMessage(ErrorMessages.CalculationRunNameMaxLengthExceeded)
-            .Matches(AlphaNumericWithAtLeastOneLetter())
+            .Matches(AlphaNumericWithSpaces())
             .WithMessage(ErrorMessages.CalculationRunNameMustBeAlphaNumeric);
     }
 
-    [GeneratedRegex("^[A-Za-z0-9 ]*[A-Za-z][A-Za-z0-9 ]*$")]
-    private static partial Regex AlphaNumericWithAtLeastOneLetter();
+    [GeneratedRegex("^[A-Za-z0-9 ]+$")] // Restricted because run names are used in generated filenames and '%'/'_' are reserved for API partial-search wildcards.
+    private static partial Regex AlphaNumericWithSpaces();
 }


### PR DESCRIPTION
Update the frontend to align with the revised calculator run API. Name-based lookups now use the query-string search endpoint instead of the previous route, reflecting the separation of search operations from explicit run ID lookups.