### PR TITLE
ECV-684 Remove inline styles, tighten CSP and add security headers

### DIFF
--- a/src/EPR.Calculator.Frontend/Program.cs
+++ b/src/EPR.Calculator.Frontend/Program.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Security.Cryptography;
 using EPR.Calculator.Frontend;
 using EPR.Calculator.Frontend.Constants;
 using EPR.Calculator.Frontend.Exceptions;
@@ -128,24 +129,30 @@ if (!app.Environment.IsDevelopment() && !app.Environment.IsLocal())
 
 app.Use(async (context, next) =>
 {
+    // Generate a unique nonce for this HTTP response.
+    var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+    context.Items["CspNonce"] = nonce;
+
     context.Response.Headers["Content-Security-Policy"] =
         "default-src 'self'; " +
-        "script-src 'self' 'unsafe-inline'; " +
-        "style-src  'self' 'unsafe-inline'; " +
-        "img-src    'self' data:; " +
-        "font-src   'self'; " +
+        $"script-src 'self' 'nonce-{nonce}'; " +
+        "style-src 'self'; " +
+        "img-src 'self' data:; " +
+        "font-src 'self'; " +
         "connect-src 'self'; " +
-        "frame-src  'self'; " +
+        "frame-src 'self'; " +
         "frame-ancestors 'self'; " +
         "form-action 'self' https://login.microsoftonline.com; " + // allow AAD sign-in POST
-        "base-uri   'self'; " +
+        "base-uri 'self'; " +
         "object-src 'none'";
 
-    context.Response.Headers.Append("X-Frame-Options", "DENY");
-    context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
+    context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+    context.Response.Headers["X-Frame-Options"] = "DENY";
+    context.Response.Headers["X-Content-Type-Options"] = "nosniff";
 
     await next();
 });
+
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();

--- a/src/EPR.Calculator.Frontend/Views/BillingInstructions/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/BillingInstructions/Index.cshtml
@@ -36,8 +36,8 @@
                         </label>
 
                         <div class="search-input-group">
-                            <input class="govuk-input" id="OrganisationId" name="@nameof(BillingInstructionsIndexModel.OrganisationId)" type="search" style="flex: 1;" value="@Model.OrganisationId" />
-                            <button type="submit" class="govuk-button" data-module="govuk-button" style="margin-bottom: 0px;">
+                            <input class="govuk-input" id="OrganisationId" name="@nameof(BillingInstructionsIndexModel.OrganisationId)" type="search" value="@Model.OrganisationId" />
+                            <button type="submit" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">
                                 Search
                             </button>
                         </div>
@@ -55,7 +55,7 @@
                                     var isChecked = Model.BillingInstructions.Contains(item);
                                     Model.InstructionCounts.TryGetValue(item, out var count);
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" type="checkbox" id="billingInstructions@(item)" name="@nameof(BillingInstructionsIndexModel.BillingInstructions)" value="@item" @(isChecked ? "checked" : "") onchange="this.form.submit();" />
+                                        <input class="govuk-checkboxes__input" type="checkbox" id="billingInstructions@(item)" name="@nameof(BillingInstructionsIndexModel.BillingInstructions)" value="@item" @(isChecked ? "checked" : "") data-submit-on-change />
                                         <label class="govuk-label govuk-checkboxes__label" for="billingInstructions@(item)">
                                             @item.GetDisplayName() (@count)
                                         </label>
@@ -77,7 +77,7 @@
                                     bool isChecked = Model.BillingStatuses.Contains(item);
                                     Model.StatusCounts.TryGetValue(item, out var count);
                                     <div class="govuk-checkboxes__item">
-                                        <input class="govuk-checkboxes__input" type="checkbox" id="billingStatuses@(item)" name="@nameof(BillingInstructionsIndexModel.BillingStatuses)" value="@item" @(isChecked ? "checked" : "") onchange="this.form.submit();" />
+                                        <input class="govuk-checkboxes__input" type="checkbox" id="billingStatuses@(item)" name="@nameof(BillingInstructionsIndexModel.BillingStatuses)" value="@item" @(isChecked ? "checked" : "") data-submit-on-change />
                                         <label class="govuk-label govuk-checkboxes__label" for="billingStatuses@(item)">
                                             @item.GetDisplayName() (@count)
                                         </label>
@@ -91,7 +91,7 @@
                         <a href="@Url.RouteUrl(
                             RouteNames.BillingInstructionsIndex, new RouteValueDictionary {
                                 ["runId"] = Model.RunId,
-                                [nameof(BillingInstructionsIndexModel.PageSize)] = Model.TablePaginationModel.PageSize })" class="govuk-button govuk-button--inverse" style="margin-bottom: 0px;">
+                                [nameof(BillingInstructionsIndexModel.PageSize)] = Model.TablePaginationModel.PageSize })" class="govuk-button govuk-button--inverse govuk-!-margin-bottom-0">
                             Clear filters
                         </a>
                     </div>
@@ -106,7 +106,7 @@
             <div class="govuk-form-group govuk-!-margin-bottom-4">
                 <div class="govuk-checkboxes govuk-checkboxes--small flex-wrap">
                     <div class="govuk-checkboxes__item checkbox-item-label">
-                        @Html.CheckBoxFor(m => m.OrganisationSelections.SelectPage, new { name = "SelectPage", @class = "govuk-checkboxes__input", onchange = "this.form.submit();" })
+                        @Html.CheckBoxFor(m => m.OrganisationSelections.SelectPage, new { name = "SelectPage", @class = "govuk-checkboxes__input", data_submit_on_change = true })
                         <label class="govuk-label govuk-checkboxes__label" for="OrganisationSelections_SelectPage">
                             Select all records on this page
                         </label>
@@ -132,8 +132,8 @@
             <div class="govuk-form-group govuk-!-margin-bottom-4">
                 <div class="govuk-checkboxes govuk-checkboxes--small flex-wrap">
                     <div class="govuk-checkboxes__item">
-                        @Html.CheckBoxFor(m => m.OrganisationSelections.SelectAll, new { name = "SelectAll", @class = "govuk-checkboxes__input", onchange = "this.form.submit();" })
-                        <label class="govuk-label govuk-checkboxes__label" for="OrganisationSelections_SelectAll" style="max-width: 100%; padding-right: 0px;">
+                        @Html.CheckBoxFor(m => m.OrganisationSelections.SelectAll, new { name = "SelectAll", @class = "govuk-checkboxes__input", data_submit_on_change = true })
+                        <label class="govuk-label govuk-checkboxes__label select-all-label" for="OrganisationSelections_SelectAll">
                             Select all @Model.ProducerIds?.Count() records
                         </label>
                         @foreach (var status in Model.BillingStatuses)
@@ -157,19 +157,19 @@
     <partial name="_BillingInstructionTable" model="Model" />
 
     <div class="govuk-button-group">
-        <form asp-action="AcceptSelected" asp-controller="BillingInstructions" method="post" onsubmit="return checkHasProducerIds();">
+        <form asp-action="AcceptSelected" asp-controller="BillingInstructions" method="post" data-check-has-producer-ids>
             <button type="submit" class="govuk-button" data-module="govuk-button" id="accept-selection-btn">
                 Accept selected
             </button>
             <input type="hidden" name="runId" value="@Model.RunId" />
         </form>
-        <form asp-action="RejectSelected" asp-controller="BillingInstructions" method="post" onsubmit="return checkHasProducerIds();">
+        <form asp-action="RejectSelected" asp-controller="BillingInstructions" method="post" data-check-has-producer-ids>
             <button type="submit" class="govuk-button govuk-button--warning" data-module="govuk-button" id="reject-selection-btn">
                 Reject selected
             </button>
             <input type="hidden" name="runId" value="@Model.RunId" />
         </form>
-        <form asp-action="ClearSelection" asp-controller="BillingInstructions" method="post" onsubmit="return checkHasProducerIds();">
+        <form asp-action="ClearSelection" asp-controller="BillingInstructions" method="post" data-check-has-producer-ids>
             <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button" id="clear-selection-btn">
                 Clear selection
             </button>
@@ -202,9 +202,24 @@
     </div>
 </div>
 
-<script type="text/javascript">
-    function checkHasProducerIds() {
-        return document.getElementById('OrganisationSelections_SelectAll').checked ||
-               Array.from(document.querySelectorAll('.record-checkbox')).some(checkbox => checkbox.checked)
-    }
+<script type="text/javascript" nonce="@Context.Items["CspNonce"]">
+    document.addEventListener("DOMContentLoaded", () => {
+        document.querySelectorAll("[data-submit-on-change]").forEach(element => {
+            element.addEventListener("change", () => {
+                element.form.submit();
+            });
+        });
+
+        document.querySelectorAll("[data-check-has-producer-ids]").forEach(form => {
+            form.addEventListener("submit", event => {
+                const checkHasProducerIds =
+                    document.getElementById('OrganisationSelections_SelectAll').checked ||
+                    Array.from(document.querySelectorAll('.record-checkbox')).some(checkbox => checkbox.checked);
+
+                if (!checkHasProducerIds) {
+                    event.preventDefault();
+                }
+            });
+        });
+    });
 </script>

--- a/src/EPR.Calculator.Frontend/Views/CalculationRunDetailsNew/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/CalculationRunDetailsNew/Index.cshtml
@@ -60,7 +60,6 @@
 
                         <a class="govuk-button govuk-button--secondary"
                            role="button"
-                           draggable="false"
                            href="@Url.Action(ActionNames.DownloadResultFile,ControllerNames.FileDownloadController, new { runId = Model.RunId })">
                             Results file
                         </a>
@@ -80,14 +79,14 @@
                                         @Html.RadioButtonFor(model => model.SelectedCalcRunOption, CalculationRunOption.OutputClassify, new { @class = "govuk-radios__input", id = "SelectedCalcRunOptionClassify" })
                                         <label class="govuk-label govuk-radios__label" for="SelectedCalcRunOptionClassify">
                                             <strong>Classify</strong><br />
-                                            <p class="govuk-body-s" style="margin-bottom: 0;">Choose a classification to process this calculation run</p>
+                                            <p class="govuk-body-s govuk-!-margin-bottom-0">Choose a classification to process this calculation run</p>
                                         </label>
                                     </div>
                                     <div class="govuk-radios__item">
                                         @Html.RadioButtonFor(model => model.SelectedCalcRunOption, CalculationRunOption.OutputDelete, new { @class = "govuk-radios__input", id = "SelectedCalcRunOptionDelete" })
                                         <label class="govuk-label govuk-radios__label" for="SelectedCalcRunOptionDelete">
                                             <strong>Delete</strong><br />
-                                            <p class="govuk-body-s" style="margin-bottom: 0;">Remove this calculation run if it's no longer needed</p>
+                                            <p class="govuk-body-s govuk-!-margin-bottom-0">Remove this calculation run if it's no longer needed</p>
                                         </label>
                                     </div>
                                 </div>

--- a/src/EPR.Calculator.Frontend/Views/CalculationRunName/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/CalculationRunName/Index.cshtml
@@ -33,7 +33,6 @@
                         </p>
                     }
                     @Html.TextBoxFor(m => m.CalculationName, new { @class = Model.Errors != null ? "govuk-input govuk-input--error" : "govuk-input govuk-input--width-20", id = "calculation-name-1", autocomplete = "name" })
-                    <div data-lastpass-icon-root="" style="position: relative !important; height: 0px !important; width: 0px !important; float: left !important;"></div>
                 </div>
             </div>
             <div class="govuk-form-group">

--- a/src/EPR.Calculator.Frontend/Views/CalculationRunOverview/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/CalculationRunOverview/Index.cshtml
@@ -45,7 +45,6 @@
                         </p>
                         <a class="govuk-button"
                            role="button"
-                           draggable="false"
                            data-module="govuk-button"
                            href="@Url.Action(ActionNames.GenerateDraftBillingFile, ControllerNames.CalculationRunOverview, new { runId = Model.Run.RunId })">
                             Retry generating new draft billing file
@@ -102,49 +101,58 @@
                                 <p class="govuk-body">Download files related to this calculation run.</p>
 
                                 <div class="govuk-button-group width-max-content">
-                                    <a class="govuk-button govuk-button--secondary"
-                                       role="button"
-                                       draggable="false"
-                                       href="@Url.Action(ActionNames.DownloadResultFile, ControllerNames.FileDownloadController, new { Model.Run.RunId })">
+                                    <a class="govuk-button govuk-button--secondary" role="button" href="@Url.Action(ActionNames.DownloadResultFile, ControllerNames.FileDownloadController, new { Model.Run.RunId })">
                                         Results file
                                     </a>
 
-                                    <a class="govuk-button govuk-button--secondary"
-                                       role="button"
-                                       draggable="false"
-                                       @(Model.IsLatestBillingFile ? null : "disabled")
-                                       onclick="return @(Model.IsLatestBillingFile ? "true" : "false");"
-                                       href="@Url.Action(ActionNames.DownloadBillingFile, ControllerNames.FileDownloadController, new { Model.Run.RunId })">
-                                        @(Model.IsBillingFileRunning ? BillingInstructionConstants.DraftBillingFileGenerating : BillingInstructionConstants.DraftBillingFile)
-                                    </a>
+                                    @if (Model.IsLatestBillingFile)
+                                    {
+                                        <a class="govuk-button govuk-button--secondary" role="button" href="@Url.Action(ActionNames.DownloadBillingFile, ControllerNames.FileDownloadController, new { Model.Run.RunId })">
+                                            @(Model.IsBillingFileRunning ? BillingInstructionConstants.DraftBillingFileGenerating : BillingInstructionConstants.DraftBillingFile)
+                                        </a>
+                                    }
+                                    else
+                                    {
+                                        <button type="button" class="govuk-button govuk-button--secondary" disabled>
+                                            @(Model.IsBillingFileRunning ? BillingInstructionConstants.DraftBillingFileGenerating : BillingInstructionConstants.DraftBillingFile)
+                                        </button>
+                                    }
 
                                     <p class="govuk-body">
                                         @(Model.IsBillingFileRunning ? BillingInstructionConstants.GenerateFileMessage : string.Empty)
                                     </p>
                                 </div>
 
-                                <a class="govuk-button govuk-button--secondary"
-                                   role="button"
-                                   draggable="false"
-                                   @(Model.IsNewBillingRunAllowed ? null : "disabled")
-                                   onclick="return @(Model.IsNewBillingRunAllowed ? "true" : "false");"
-                                   href="@Url.Action(ActionNames.GenerateDraftBillingFile, ControllerNames.CalculationRunOverview, new { Model.Run.RunId })">
-                                    @(BillingInstructionConstants.GenerateNewDraftBillingFile)
-                                </a>
+                                @if (Model.IsNewBillingRunAllowed)
+                                {
+                                    <a class="govuk-button govuk-button--secondary" role="button" href="@Url.Action(ActionNames.GenerateDraftBillingFile, ControllerNames.CalculationRunOverview, new { Model.Run.RunId })">
+                                        @(BillingInstructionConstants.GenerateNewDraftBillingFile)
+                                    </a>
+                                }
+                                else
+                                {
+                                    <button type="button" class="govuk-button govuk-button--secondary" disabled>
+                                        @(BillingInstructionConstants.GenerateNewDraftBillingFile)
+                                    </button>
+                                }
 
                                 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
                                 <h2 class="govuk-heading-m">Remove this run's classification</h2>
                                 <p class="govuk-body">Mark this run as a test or delete it to remove its classification.</p>
-                                <div class="govuk-button-group">
-                                    <a class="govuk-button govuk-button--secondary"
-                                       role="button"
-                                       draggable="false"
-                                       @(Model.IsRemoveClassificationAllowed ?  null : "disabled")
-                                       onclick="return @(Model.IsRemoveClassificationAllowed ? "true" : "false");"
-                                       href="@Url.Action(@ActionNames.Index, @ControllerNames.CalculationRunDelete, new { Model.Run.RunId })">
+
+
+                                @if (Model.IsRemoveClassificationAllowed)
+                                {
+                                    <a class="govuk-button govuk-button--secondary" role="button" href="@Url.Action(@ActionNames.Index, @ControllerNames.CalculationRunDelete, new { Model.Run.RunId })">
                                         Remove classification
                                     </a>
-                                </div>
+                                }
+                                else
+                                {
+                                    <button type="button" class="govuk-button govuk-button--secondary" disabled>
+                                        Remove classification
+                                    </button>
+                                }
 
                                 <partial name="_AmendBillingInstructionPartial" model="Model.Run" />
 

--- a/src/EPR.Calculator.Frontend/Views/ClassifyRunConfirmation/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/ClassifyRunConfirmation/Index.cshtml
@@ -56,7 +56,6 @@
 
                         <a class="govuk-button govuk-button--secondary"
                            role="button"
-                           draggable="false"
                            href="@Url.Action( ActionNames.DownloadResultFile ,ControllerNames.FileDownloadController, new { runId = Model.CalculatorRunDetails.RunId })">
                             Results file
                         </a>
@@ -99,7 +98,6 @@
                         <div class="govuk-button-group">
                             <a class="govuk-button"
                                role="button"
-                               draggable="false"
                                href="@Url.Action(ActionNames.Index, ControllerNames.BillingInstructionsController, new { runId = Model.CalculatorRunDetails.RunId })">
                                 Continue
                             </a>

--- a/src/EPR.Calculator.Frontend/Views/Dashboard/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/Dashboard/Index.cshtml
@@ -57,7 +57,7 @@
     </div>
 </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="@Context.Items["CspNonce"]">
     $(document).ready(() => {
         var relativeYearListDropdown = $('#financial-year-list');
 

--- a/src/EPR.Calculator.Frontend/Views/DefaultParameters/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/DefaultParameters/Index.cshtml
@@ -88,7 +88,7 @@
 
 </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="@Context.Items["CspNonce"]">
     $(document).ready(() => {
         const [dateString, timeString] = ("@Model.EffectiveFrom").split(' ');
 

--- a/src/EPR.Calculator.Frontend/Views/FileDownload/DownloadError.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/FileDownload/DownloadError.cshtml
@@ -9,8 +9,10 @@
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-form-group ">
                 <h1 class="govuk-heading-l">There was a problem downloading this file</h1>
-                <h1 class="govuk-body-m">This file has not been downloaded. </h1>
-                <a href="javascript:history.back()" class="govuk-button" type="submit">Try again</a>
+                <p class="govuk-body-m">This file has not been downloaded.</p>
+                <a href="@Url.Action("Index", "Dashboard")" class="govuk-button" data-history-back>
+                    Try again
+                </a>
                 <p class="govuk-body">
                     <a href="@Url.Action("Index", "Dashboard")" class="govuk-link">Return to the dashboard</a>
                 </p>
@@ -18,3 +20,16 @@
         </div>
     </div>
 </main>
+
+<script type="text/javascript" nonce="@Context.Items["CspNonce"]">
+    document.addEventListener("DOMContentLoaded", () => {
+        document.querySelectorAll("[data-history-back]").forEach(element => {
+            element.addEventListener("click", event => {
+                if (window.history.length > 1) {
+                    event.preventDefault();
+                    window.history.back();
+                }
+            });
+        });
+    });
+</script>

--- a/src/EPR.Calculator.Frontend/Views/LocalAuthorityDisposalCosts/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/LocalAuthorityDisposalCosts/Index.cshtml
@@ -57,7 +57,7 @@
 
 @if (Model != null && Model?.ByCountry?.Count > 0)
 {
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="@Context.Items["CspNonce"]">
         $(document).ready(() => {
             const [dateString, timeString] = ('@EffectiveFromDate').split(' ');
 

--- a/src/EPR.Calculator.Frontend/Views/LocalAuthorityUploadFile/Processing.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/LocalAuthorityUploadFile/Processing.cshtml
@@ -7,7 +7,7 @@
 
 <partial name="_RefreshPartial" />
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="@Context.Items["CspNonce"]">
     $(function () {
         const payload = JSON.stringify(@localAuthorityDisposalCosts)
         const url = '@Url.Action("Process", "LocalAuthorityUploadFile")'

--- a/src/EPR.Calculator.Frontend/Views/ParameterUploadFile/Refresh.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/ParameterUploadFile/Refresh.cshtml
@@ -9,6 +9,6 @@
 
 <partial name="_RefreshPartial"  />
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="@Context.Items["CspNonce"]">
     processAndUploadData(@schemeParameterValues, '/ParameterUploadFileProcessing', '/ParameterConfirmation', 'ParameterUploadFileError');
 </script>

--- a/src/EPR.Calculator.Frontend/Views/PostBillingFile/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/PostBillingFile/Index.cshtml
@@ -56,14 +56,12 @@
                     <div class="govuk-button-group">
                         <a class="govuk-button govuk-button--secondary"
                            role="button"
-                           draggable="false"
                            href="@Url.Action(ActionNames.DownloadResultFile, ControllerNames.FileDownloadController, new { runId = Model.CalculatorRunStatus.RunId })">
                             Results file
                         </a>
 
                         <a class="govuk-button govuk-button--secondary"
                            role="button"
-                           draggable="false"
                            href="@Url.Action(ActionNames.DownloadBillingFile, ControllerNames.FileDownloadController, new { runId = Model.CalculatorRunStatus.RunId })">
                             Billing file
                         </a>

--- a/src/EPR.Calculator.Frontend/Views/ReasonForRejection/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/ReasonForRejection/Index.cshtml
@@ -12,17 +12,17 @@
 
             <div class="govuk-grid-row">
                 <div class="@(ViewContext.ModelState.IsValid ?  "govuk-form-group govuk-grid-column-full" : "govuk-form-group govuk-form-group--error" )">
-                        <span class="govuk-caption-xl">@Model.RunName</span>
+                    <span class="govuk-caption-xl">@Model.RunName</span>
                     <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Give a reason for rejecting billing instructions</h1>
-                    <p class="@(ViewContext.ModelState.IsValid ? "govuk-body govuk-!-margin-bottom-2" : "govuk-body govuk-!-margin-bottom-2 govuk-error-message" )">Provide a reason that applies to all the billing instructions you selected for rejection.</p>
-                        <div class="govuk-grid-column-two-thirds" style="padding:0px;">
-
+                    <p class="@(ViewContext.ModelState.IsValid ? "govuk-body govuk-!-margin-bottom-2" : "govuk-body govuk-!-margin-bottom-2 govuk-error-message" )">
+                        Provide a reason that applies to all the billing instructions you selected for rejection.
+                    </p>
+                    <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
                         <div class="govuk-form-group">
                             @Html.ValidationMessageFor(m => m.Reason, "", new { @class = "govuk-error-message" })
-                            @Html.LabelFor(m => m.Reason, new { style = "display: none;" } )
+                            @Html.LabelFor(m => m.Reason, new { @class = "govuk-visually-hidden" })
                             @Html.TextAreaFor(m => m.Reason, new { @class = "govuk-textarea form-control text-area-margin-bottom", @aria_label = "Free‑text box to record why you rejected the selected instructions.", rows = 5 })
                         </div>
-
                     </div>
                 </div>
                 <div class="govuk-form-group">

--- a/src/EPR.Calculator.Frontend/Views/SetRunClassification/Index.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/SetRunClassification/Index.cshtml
@@ -60,7 +60,7 @@
                                                 @Html.RadioButtonFor(model => model.ClassifyRunType, classfication.Id, new { @class = "govuk-radios__input", id = classfication.Status })
                                             <label class="govuk-label govuk-radios__label" for="@classfication.Status">
                                                     <strong>@classfication.Status</strong><br />
-                                                <p class="govuk-body-s" style="margin-bottom: 0;">
+                                                <p class="govuk-body-s govuk-!-margin-bottom-0">
                                                         @classfication.Description
                                                 </p>
                                             </label>

--- a/src/EPR.Calculator.Frontend/Views/Shared/_AmendBillingInstructionPartial.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/Shared/_AmendBillingInstructionPartial.cshtml
@@ -1,12 +1,24 @@
 ﻿@using EPR.Calculator.Frontend.Enums
 @model CalculatorRunDto
+
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
 <h2 class="govuk-heading-m">@BillingInstructionConstants.AmendBillingInstructions</h2>
+
 <p class="govuk-body">@BillingInstructionConstants.AmendBillingInstructionText</p>
+
 <div class="govuk-button-group">
-    <a href="@($"/{ControllerNames.BillingInstructionsController}/{Model.RunId}")"
-       class="govuk-button govuk-button--secondary" @(Model.BillingRunStatus == BillingRunStatus.Running ? "disabled" : null)
-       onclick="return @(Model.BillingRunStatus == BillingRunStatus.Running ? "false" : "true");">
-        @BillingInstructionConstants.AmendBillingInstructions
-    </a>
+    @if (Model.BillingRunStatus != BillingRunStatus.Running)
+    {
+        <a href="@($"/{ControllerNames.BillingInstructionsController}/{Model.RunId}")"
+           class="govuk-button govuk-button--secondary">
+            @BillingInstructionConstants.AmendBillingInstructions
+        </a>
+    }
+    else
+    {
+        <button type="button" class="govuk-button govuk-button--secondary" disabled>
+            @BillingInstructionConstants.AmendBillingInstructions
+        </button>
+    }
 </div>

--- a/src/EPR.Calculator.Frontend/Views/Shared/_BillingInstructionTable.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/Shared/_BillingInstructionTable.cshtml
@@ -111,9 +111,9 @@
     }
 }
 
-<div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap;">
+<div class="billing-pagination">
     <!-- Left side: pagination numbers + next -->
-    <div style="display: flex; align-items: center; gap: 10px;">
+    <div class="billing-pagination__pages">
         <ul class="govuk-pagination__list">
             @* Previous link *@
             @if (Model.TablePaginationModel.Page > 1)
@@ -143,7 +143,7 @@
             @* Pages in the block *@
             @for (int i = blockStart; i <= blockEnd; i++)
             {
-                <li class="govuk-pagination__item @(Model.TablePaginationModel.Page == i ? "govuk-pagination__item--current" : "")" @(Model.TablePaginationModel.Page == i ? "aria-current=\"page\"" : "") style="text-decoration: underline;">
+                <li class="govuk-pagination__item @(Model.TablePaginationModel.Page == i ? "govuk-pagination__item--current" : "")" @(Model.TablePaginationModel.Page == i ? "aria-current=\"page\"" : "")>
                     @if (Model.TablePaginationModel.Page == i)
                     {
                         @i
@@ -189,18 +189,18 @@
     <!-- Right side: items per page -->
     <div>
         <strong class="govuk-body">Items per page:</strong>
-        <ul class="govuk-pagination__list" style="display: inline-flex; list-style: none;">
+        <ul class="govuk-pagination__list pagination-page-size-list">
             @foreach (var size in Model.TablePaginationModel.PageSizeOptions)
             {
                 if (Model.TablePaginationModel.PageSize == size)
                 {
-                    <li class="govuk-pagination__item" style="min-width:20px; padding-left: 5px; padding-right: 5px;">
+                    <li class="govuk-pagination__item pagination-page-size">
                         <strong>@size</strong>
                     </li>
                 }
                 else
                 {
-                    <li class="govuk-pagination__item" style="min-width:20px; padding-left: 5px; padding-right: 5px">
+                    <li class="govuk-pagination__item pagination-page-size">
                         <a class="govuk-link govuk-pagination__link govuk-link--no-visited-state"
                            href="@Url.RouteUrl(Model.TablePaginationModel.RouteName, RouteValues(1, pageSize: size))"
                            aria-label="Show @size items per page">
@@ -227,7 +227,7 @@
     Update billing instructions for <span id="totalCountText">@ARJourneySessionHelper.GetFromSession(Context.Session).Count</span> selected organisations.
 </p>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="@Context.Items["CspNonce"]">
     document.addEventListener('click', function (event) {
         if (event.target.classList.contains('record-checkbox')) {
             var organisationId = event.target.getAttribute('data-organisation-id');

--- a/src/EPR.Calculator.Frontend/Views/Shared/_BillingInstructionsPartial.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/Shared/_BillingInstructionsPartial.cshtml
@@ -16,7 +16,7 @@
         </h2>
     </div>
     <div class="govuk-notification-banner__content">
-        <h3 class="govuk-notification-banner__heading" style="max-width: fit-content;">
+        <h3 class="govuk-notification-banner__heading">
             @Html.Raw(message)
         </h3>
     </div>

--- a/src/EPR.Calculator.Frontend/Views/Shared/_Layout.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/Shared/_Layout.cshtml
@@ -16,9 +16,6 @@
 </head>
 
 <body class="govuk-template__body js-enabled">
-    <script>
-        document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
     <header class="govuk-header" data-module="govuk-header">
         <div class="govuk-header__container govuk-width-container">
@@ -53,11 +50,11 @@
 
     <div class="govuk-phase-banner govuk-width-container">
         <p class="govuk-phase-banner__content">
-            <strong class="govuk-tag govuk-phase-banner__content__tag" style="Color: #ffffff;background-color: #1d70b8;">
-                <b>BETA</b>
+            <strong class="govuk-tag govuk-phase-banner__content__tag">
+                BETA
             </strong>
             <span class="govuk-phase-banner__text">
-                This is a new service - your <a href="#" class="govuk-link:link">feedback</a> will help us improve it.
+                This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us improve it.
             </span>
         </p>
     </div>
@@ -116,14 +113,7 @@
         </div>
     </footer>
     <script type="module" src="~/js/govuk-frontend-5.4.1.min.js"></script>
-    <script>
-
-
-    </script>
-    <script type="module">
-        import { initAll } from '~/js/govuk-frontend-5.4.1.min.js'
-        initAll()
-    </script>
+    <script type="module" src="~/js/govuk-init.js"></script>
 </body>
 
 </html>

--- a/src/EPR.Calculator.Frontend/Views/Shared/_Layout.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/Shared/_Layout.cshtml
@@ -15,12 +15,12 @@
     <link rel="stylesheet" href="~/css/site.css" />
 </head>
 
-<body class="govuk-template__body js-enabled">
+<body class="govuk-template__body js-enabled govuk-frontend-supported">
     <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
     <header class="govuk-header" data-module="govuk-header">
         <div class="govuk-header__container govuk-width-container">
             <div class="govuk-header__logo">
-                <a href="#" class="govuk-header__link govuk-header__link--homepage">
+                <a href="/" class="govuk-header__link govuk-header__link--homepage">
                     <svg focusable="false"
                          role="img"
                          class="govuk-header__logotype"
@@ -36,14 +36,9 @@
             </div>
 
             <div class="govuk-header__content">
-
-
                 <a href="/" class="govuk-header__link govuk-header__service-name">
                     Run the fees and payments calculator
                 </a>
-
-
-
             </div>
         </div>
     </header>
@@ -112,7 +107,6 @@
             </div>
         </div>
     </footer>
-    <script type="module" src="~/js/govuk-frontend-5.4.1.min.js"></script>
     <script type="module" src="~/js/govuk-init.js"></script>
 </body>
 

--- a/src/EPR.Calculator.Frontend/Views/Shared/_ShowRunDetailPartial.cshtml
+++ b/src/EPR.Calculator.Frontend/Views/Shared/_ShowRunDetailPartial.cshtml
@@ -27,7 +27,7 @@
 
     @if (Model.ShowStatus)
     {
-        <dd class="govuk-summary-list__actions" style="text-align: center;">
+        <dd class="govuk-summary-list__actions govuk-!-text-align-centre">
             <strong class="@Model.TagStyle">
                 @Model.RunClassification.GetDisplayName()
             </strong>

--- a/src/EPR.Calculator.Frontend/wwwroot/css/site.css
+++ b/src/EPR.Calculator.Frontend/wwwroot/css/site.css
@@ -79,6 +79,10 @@ body {
     gap: 10px;
 }
 
+.search-input-group .govuk-input {
+    flex: 1;
+}
+
 .govuk-link--selected-status {
     outline: 3px solid transparent;
     color: #0b0c0c;
@@ -118,4 +122,31 @@ body {
 
 .govuk-button--secondary[disabled] {
     opacity: 0.65; /*Fix accessibility contrast issue*/
+}
+
+.select-all-label {
+    max-width: 100%;
+    padding-right: 0;
+}
+
+.billing-pagination {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.billing-pagination__pages {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.pagination-page-size-list {
+    display: inline-flex;
+}
+
+.pagination-page-size {
+    min-width: 20px;
+    padding: 0 5px;
 }

--- a/src/EPR.Calculator.Frontend/wwwroot/js/govuk-init.js
+++ b/src/EPR.Calculator.Frontend/wwwroot/js/govuk-init.js
@@ -1,0 +1,3 @@
+import { initAll } from './govuk-frontend-5.4.1.min.js';
+
+initAll();


### PR DESCRIPTION
Summary:
- Removed inline styles and moved styling into external CSS.
- Tightened the Content Security Policy by removing unsafe-inline.
- Added/updated security headers including Referrer-Policy.
- Updated disabled button markup to use the appropriate GOV.UK button styling and accessibility semantics.
- Removed unnecessary inline/third-party injected markup.